### PR TITLE
Interrupt payload reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ mosquitto_sub -h <broker url> -t <topic prefix>/stream/serialrx -N
 mosquitto_pub -h <broker url> -t <topic prefix>/stream/serialtx -m "testing123\r\n"
 ```
 
+Also, you can use `interrupt_payload: "ON"` in pair with `interrupt_payload_reset: "OFF"` for HomeAssistant. 
+
+E.g. motion sensors could be integrated more seamlessly like that.
+
+
 ### OrangePi boards
 
 You need to specify what OrangePi board you use

--- a/config.schema.yml
+++ b/config.schema.yml
@@ -210,6 +210,10 @@ digital_inputs:
         type: string
         required: no
         default: "INT"
+      interrupt_payload_reset:
+        type: string
+        required: no
+        default: "OFF"
       pullup:
         type: boolean
         required: no

--- a/pi_mqtt_gpio/server.py
+++ b/pi_mqtt_gpio/server.py
@@ -918,6 +918,14 @@ def gpio_interrupt_callback(module, pin):
         payload=in_conf["interrupt_payload"],
         retain=in_conf["retain"],
     )
+    # publish reset payload of the interrupt trigger
+    # For example, HomeAssistant motion sensor should send clear signal (OFF) after motion one (ON)
+    if in_conf["interrupt_payload_reset"]:
+        client.publish(
+            "%s/%s/%s" % (topic_prefix, INPUT_TOPIC, in_conf["name"]),
+            payload=in_conf["interrupt_payload_reset"],
+            retain=in_conf["retain"],
+        )
 
 
 def hass_announce_digital_input(in_conf, topic_prefix, mqtt_config):


### PR DESCRIPTION
For example, HomeAssistant motion sensor should send clear signal (OFF) after motion one (ON)